### PR TITLE
fix spell from 'php' to 'python'

### DIFF
--- a/pages/20.python-docker/03.python-docker-002/docs.md
+++ b/pages/20.python-docker/03.python-docker-002/docs.md
@@ -88,7 +88,7 @@ FROM daocloud.io/ubuntu:trusty
 # 道客船长荣誉出品
 MAINTAINER Captain Dao <support@daocloud.io>
 
-# APT 自动安装 PHP 相关的依赖包，如需其他依赖包在此添加
+# APT 自动安装 Python 相关的依赖包，如需其他依赖包在此添加
 RUN apt-get update && \
   	apt-get install -y python \
     				   python-dev \


### PR DESCRIPTION
Python才对，写成了php