### PR TITLE
typo fix

### DIFF
--- a/pages/23.java-docker/05.docker-tomcat-war-java/docs.md
+++ b/pages/23.java-docker/05.docker-tomcat-war-java/docs.md
@@ -96,7 +96,7 @@ RUN cd /tmp/build && mvn -q -DskipTests=true package \
         && cd / && rm -rf /tmp/build
 
 EXPOSE 8080
-CMD["catalina.sh","run"]
+CMD ["catalina.sh","run"]
 ```
 
 


### PR DESCRIPTION
这里缺少一个空格，非常隐蔽，直接复制代码容易导致执行失败