### PR TITLE
dce5-installer: update clusterConfig.yaml

### DIFF
--- a/docs/en/docs/install/commercial/clusterconfig.md
+++ b/docs/en/docs/install/commercial/clusterconfig.md
@@ -13,7 +13,7 @@ This file will define key parameters such as the deployed load balancing type, d
 The following is an example ClusterConfig file( assuming the bootstrap node IP is 10.6.127.220)
 
 ```yaml title="clusterConfig.yaml"
-apiVersion: provision.daocloud.io/v1alpha2
+apiVersion: provision.daocloud.io/v1alpha3
 kind: ClusterConfig
 metadata:
   creationTimestamp: null

--- a/docs/en/docs/install/community/k8s/offline.md
+++ b/docs/en/docs/install/community/k8s/offline.md
@@ -118,7 +118,7 @@ This page briefly describes the offline installation steps for DCE 5.0 Community
     - If it is a non-public cloud environment (virtual machine, physical machine), please enable load balancing (metallb) to avoid NodePort instability caused by node IP changes. Please plan your network carefully and set up 2 necessary VIPs. The configuration file example is as follows:
 
         ```yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -137,7 +137,7 @@ This page briefly describes the offline installation steps for DCE 5.0 Community
     - If it is a public cloud environment and provides the k8s load balancing capability of the public cloud through the pre-prepared Cloud Controller Manager mechanism, the configuration file example is as follows:
 
         ```yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -152,7 +152,7 @@ This page briefly describes the offline installation steps for DCE 5.0 Community
     - If NodePort is used to expose the console (only recommended for PoC), the configuration file example is as follows:
 
         ```yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:

--- a/docs/en/docs/install/community/k8s/online.md
+++ b/docs/en/docs/install/community/k8s/online.md
@@ -51,7 +51,7 @@ This page briefly explains the online installation steps for DCE 5.0 Community E
     - If it is a non-public cloud environment (virtual machine, physical machine), please enable load balancing (metallb) to avoid NodePort instability caused by node IP changes. Please plan your network carefully and set up 2 necessary VIPs. The configuration file example is as follows:
 
         ```yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -66,7 +66,7 @@ This page briefly explains the online installation steps for DCE 5.0 Community E
     - If it is a public cloud environment and provides the K8s load balancing capability of the public cloud through the pre-prepared Cloud Controller Manager mechanism, the configuration file example is as follows:
 
         ```yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:

--- a/docs/en/docs/install/install-dce-community.md
+++ b/docs/en/docs/install/install-dce-community.md
@@ -54,7 +54,7 @@ This page describes the installation procedure of DCE 5.0.
     - For a private cloud (virtual and physical machines), enable your load balancer (metallb) to avoid the NodePort instability caused by IP variations. Carefully plan your network and IP addresses. Here is an example for your reference:
 
         ```yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -66,7 +66,7 @@ This page describes the installation procedure of DCE 5.0.
     - For a public cloud, DCE integrates a Cloud Controller Manager to provide the load balancing capability for kubernetes. Here is an example for your reference:
 
         ``` yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -102,7 +102,7 @@ This page describes the installation procedure of DCE 5.0.
 1. Ensure the port 32000 has been exposed to port 8888 from your cluster to external when you create the cluster with kind. The kind profile looks like:
         
     ``` yaml
-    apiVersion: provision.daocloud.io/v1alpha2
+    apiVersion: provision.daocloud.io/v1alpha3
     kind: ClusterConfig
     spec:
       loadBalancer:

--- a/docs/en/docs/install/offline-intall-community.md
+++ b/docs/en/docs/install/offline-intall-community.md
@@ -123,7 +123,7 @@ This page describes the air-gap (offline) installation procedure of DCE 5.0.
     - For a private cloud (virtual and physical machines), enable your load balancer (metallb) to avoid the NodePort instability caused by IP variations. Carefully plan your network and IP addresses. Here is an example for your reference:
 
         ```yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -138,7 +138,7 @@ This page describes the air-gap (offline) installation procedure of DCE 5.0.
     - For a public cloud, DCE integrates a Cloud Controller Manager to provide the load balancing capability for kubernetes. Here is an example for your reference:
 
         ``` yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -151,7 +151,7 @@ This page describes the air-gap (offline) installation procedure of DCE 5.0.
     - If you use NodePort to expose your console (for proof of concept (PoC)), refer to the following example:
 
         ``` yaml
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:

--- a/docs/zh/docs/install/community/k8s/offline.md
+++ b/docs/zh/docs/install/community/k8s/offline.md
@@ -42,7 +42,7 @@
     - 如果是非公有云环境（虚拟机、物理机），请启用负载均衡 (metallb)，以规避 NodePort 因节点 IP 变动造成的不稳定。请仔细规划您的网络，设置 2 个必要的 VIP，配置文件范例如下：
 
         ```yaml title="clusterConfig.yaml"
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -60,7 +60,7 @@
     - 如果是公有云环境，并通过预先准备好的 Cloud Controller Manager 的机制提供了公有云的 k8s 负载均衡能力, 配置文件范例如下:
 
         ```yaml title="clusterConfig.yaml"
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -76,7 +76,7 @@
     - 如果使用 NodePort 暴露控制台（仅推荐 PoC 使用），配置文件范例如下:
 
         ```yaml title="clusterConfig.yaml"
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:

--- a/docs/zh/docs/install/community/k8s/online.md
+++ b/docs/zh/docs/install/community/k8s/online.md
@@ -45,7 +45,7 @@
     - 如果是非公有云环境（虚拟机、物理机），请启用负载均衡 (metallb)，以规避 NodePort 因节点 IP 变动造成的不稳定。请仔细规划您的网络，设置 2 个必要的 VIP，配置文件范例如下：
 
         ```yaml title="clusterConfig.yaml"
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:
@@ -60,7 +60,7 @@
     - 如果是公有云环境，并通过预先准备好的 Cloud Controller Manager 的机制提供了公有云的 K8s 负载均衡能力, 配置文件范例如下:
 
         ```yaml title="clusterConfig.yaml"
-        apiVersion: provision.daocloud.io/v1alpha2
+        apiVersion: provision.daocloud.io/v1alpha3
         kind: ClusterConfig
         spec:
           loadBalancer:


### PR DESCRIPTION
update apiVersion to `provision.dao…cloud.io/v1alpha3`

```bash
root@k3sdce5:~# ./dce5-installer install-app -c clusterConfig.yaml -z
[Error]:[Error] invalid ClusterConfig: invalid apiVersion: provision.daocloud.io/v1alpha2, only support provision.daocloud.io/v1alpha3
root@k3sdce5:~# cat clusterConfig.yaml
apiVersion: provision.daocloud.io/v1alpha2
kind: ClusterConfig
spec:
  loadBalancer:
    type: metallb
    istioGatewayVip: 10.211.55.232/32 #
    insightVip: 10.211.55.231/32      #
```