### PR TITLE
update kpanda download page

### DIFF
--- a/docs/en/docs/download/modules/kpanda.md
+++ b/docs/en/docs/download/modules/kpanda.md
@@ -1,6 +1,6 @@
 # Container Management
 
-This page provides offline installation packages for different versions of the observability module.
+This page provides offline installation packages for different versions of the Container Management module.
 
 ## Download
 

--- a/docs/zh/docs/download/modules/kpanda.md
+++ b/docs/zh/docs/download/modules/kpanda.md
@@ -1,12 +1,11 @@
 # 容器管理 Kpanda
 
-本页可下载可观测性模块各版本的离线安装包。
+本页可下载容器管理模块各版本的离线安装包。
 
 ## 下载
 
 | 版本                                            | 架构 | 文件大小 | 安装包                                                                                                                             |  校验文件 | 更新日期      |
 |-----------------------------------------------| ----- |-------- |---------------------------------------------------------------------------------------------------------------------------------| ---------- |-----------|
-| [0.20.0+dev-2f4f4368](../../kpanda/intro/release-notes.md) | AMD 64 | 653.91MB | [:arrow_down: kpanda_0.20.0+dev-2f4f4368_amd64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/kpanda_0.20.0+dev-2f4f4368_amd64.tar) | [:arrow_down: kpanda_0.20.0+dev-2f4f4368_amd64_checksum.sha512sum](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/kpanda_0.20.0+dev-2f4f4368_amd64_checksum.sha512sum) | 2023-07-27 |
 | [v0.19.0](../../kpanda/intro/release-note.md) | AMD64 | 2.41GB | [:arrow_down: kpanda_v0.19.0_amd64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/kpanda_v0.19.0_amd64.tar) | [:arrow_down: kpanda_v0.19.0_amd64_checksum.sha512sum](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/kpanda_v0.19.0_amd64_checksum.sha512sum) | 2023-7-06 |
 
 ## 校验
@@ -24,7 +23,6 @@ kpanda_v0.19.0_amd64.tar: ok
 ```
 
 ## 安装
-
 
 如果是初次安装，请[申请免费体验](../../dce/license0.md)或联系我们授权：电邮 info@daocloud.io 或致电 400 002 6898。
 如果有任何许可密钥相关的问题，请联系 DaoCloud 交付团队。


### PR DESCRIPTION
- Fix typo
- Remove `0.20.0+dev-2f4f4368` link to download since its checksum is incorrect and the suffix `+dev-2f4f4368` indicates it is not a officially released version
