### PR TITLE
update the latest installer version and avoid ambiguity

### DIFF
--- a/docs/en/docs/install/commercial/prepare.md
+++ b/docs/en/docs/install/commercial/prepare.md
@@ -47,26 +47,27 @@ Refer to [7 Nodes Mode](./deploy-arch.md#7-1-6).
 ### Bootstraping Node Dependency Check
 
 | **Check Item**   | **Versions** | **Description** |
-| ---------------- | ------------------------ | --------------- |
-| podman           | v4.4.1                   | -               |
-| helm             | ≥ 3.11.1                  | -               |
-| skopeo           | ≥ 1.11.1                  | -               |
-| kind             | v0.17.0                | -               |
-| kubectl          | ≥ 1.25.6                 | -               |
-| yq               | ≥ 4.31.1                 | -               |
-| MinIO client     | -                        | `mc.RELEASE.2023-02-16T
+| ---------------- |-------------| --------------- |
+| podman           | v4.4.1      | -               |
+| helm             | ≥ 3.11.1    | -               |
+| skopeo           | ≥ 1.11.1    | -               |
+| kind             | v0.19.0     | -               |
+| kubectl          | ≥ 1.25.6    | -               |
+| yq               | ≥ 4.31.1    | -               |
+| MinIO client     | `mc.RELEASE.2023-02-16T19-20-11Z`            | -|
 
 If these dependencies have not been installed, refer to [Install Dependencies](../install-tools.md)。
 
 ```bash
+export VERSION=v0.9.0
 # download install script
-curl -LO https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite.sh
+curl -LO https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite_${VERSION}.sh
 
 # add execution permission
-chmod +x install_prerequisite.sh
+chmod +x install_prerequisite_${VERSION}.sh
 
 # start install
-bash install_prerequisite.sh online full
+bash install_prerequisite_${VERSION}.sh online full
 ```
 
 ## External Component Preparation

--- a/docs/en/docs/install/install-tools.md
+++ b/docs/en/docs/install/install-tools.md
@@ -24,7 +24,7 @@ Before installing DCE 5.0, you need to install some dependencies.
 1. Download the script.
 
     ```bash
-    export VERSION=v0.8.0
+    export VERSION=v0.9.0
     curl -LO https://proxy-qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite_${VERSION}.sh
     ```
 
@@ -55,14 +55,14 @@ Offline installation means that the target host is in an offline state and canno
 1. Download the script.
 
     ```bash
-    export VERSION=v0.8.0
+    export VERSION=v0.9.0
     curl -LO https://proxy-qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite_${VERSION}.sh
     ```
 
 2. Download the offline package for prerequisites.
 
     ```bash
-    export VERSION=v0.8.0
+    export VERSION=v0.9.0
     curl -LO https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/prerequisite_${VERSION}_amd64.tar.gz
     ```
 

--- a/docs/zh/docs/install/commercial/prepare.md
+++ b/docs/zh/docs/install/commercial/prepare.md
@@ -47,27 +47,28 @@
 
 ### 火种机器依赖组件检查
 
-| **检查项**   | **版本要求** | **说明**                          |
-| ------------ | ------------ | --------------------------------- |
-| podman       | v4.4.1       | -                                 |
-| helm         | ≥ 3.11.1      | -                                 |
-| skopeo       | ≥ 1.11.1      | -                                 |
-| kind         | v0.17.0    | -                                 |
-| kubectl      | ≥ 1.25.6     | -                                 |
-| yq           | ≥ 4.31.1     | -                                 |
-| minio client | `mc.RELEASE.2023-02-16T19-20-11Z``mc.RELEASE.2023-02-16T19-20-11Z` |                   |
+| **检查项**   | **版本要求**                                                           | **说明**                          |
+| ------------ |--------------------------------------------------------------------| --------------------------------- |
+| podman       | v4.4.4                                                             | -                                 |
+| helm         | ≥ 3.11.1                                                           | -                                 |
+| skopeo       | ≥ 1.11.1                                                           | -                                 |
+| kind         | v0.19.0                                                            | -                                 |
+| kubectl      | ≥ 1.25.6                                                           | -                                 |
+| yq           | ≥ 4.31.1                                                           | -                                 |
+| minio client | `mc.RELEASE.2023-02-16T19-20-11Z`                                 |                   |
 
 如果不存在依赖组件，通过脚本进行安装依赖组件，[安装前置依赖](../install-tools.md)。
 
 ```bash
+export VERSION=v0.9.0
 # 下载脚本
-curl -LO https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite.sh
+curl -LO https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite_${VERSION}.sh
 
 # 添加可执行权限
-chmod +x install_prerequisite.sh
+chmod +x install_prerequisite_${VERSION}.sh
 
 # 开始安装
-bash install_prerequisite.sh online full
+bash install_prerequisite_${VERSION}.sh online full
 ```
 
 ## 外接组件准备

--- a/docs/zh/docs/install/install-tools.md
+++ b/docs/zh/docs/install/install-tools.md
@@ -24,7 +24,7 @@
 1. 下载脚本。
 
     ```bash
-    export VERSION=v0.8.0
+    export VERSION=v0.9.0   # 安装器版本
     curl -LO https://proxy-qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite_${VERSION}.sh
     ```
 
@@ -55,14 +55,14 @@
 1. 下载脚本。
 
     ```bash
-    export VERSION=v0.8.0
+    export VERSION=v0.9.0
     curl -LO https://proxy-qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/install_prerequisite_${VERSION}.sh
     ```
 
 2. 下载前置依赖组件离线包。
 
     ```bash
-    export VERSION=v0.8.0
+    export VERSION=v0.9.0
     curl -LO https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/prerequisite_${VERSION}_amd64.tar.gz
     ```
 


### PR DESCRIPTION
In the original document of installing DCE5 Commercial,  the version of install_prerequisite is v0.8.0, but the dependent offline package isv0.9.0.  To avoid ambiguity and update to the latest installer version, we make the PR.
<img width="1357" alt="image" src="https://github.com/DaoCloud/DaoCloud-docs/assets/139965836/5a746ad1-bdb3-45cc-9e41-6432553e09e7">

<img width="1492" alt="image" src="https://github.com/DaoCloud/DaoCloud-docs/assets/139965836/ebef0500-160e-48f7-ad26-bd516f30d918">
