### PR TITLE
Fix the issue with the document's ending suffix '/'.

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -19,6 +19,8 @@ repo_name: DaoCloud/DaoCloud-docs
 repo_url: https://github.com/DaoCloud/DaoCloud-docs
 edit_uri: edit/main/docs/en/docs/
 
+use_directory_urls: false # disbale https://www.mkdocs.org/user-guide/configuration/#use_directory_urls
+
 # Configuration
 theme:
   name: material
@@ -29,6 +31,7 @@ theme:
   include_search_page: false
   search_index_only: true
   include_homepage_in_sidebar: false
+ 
 
   # Static files
   static_templates:

--- a/docs/zh/mkdocs.yml
+++ b/docs/zh/mkdocs.yml
@@ -18,6 +18,8 @@ repo_name: DaoCloud/DaoCloud-docs
 repo_url: https://github.com/DaoCloud/DaoCloud-docs
 edit_uri: edit/main/docs/zh/docs/
 
+use_directory_urls: false # disbale https://www.mkdocs.org/user-guide/configuration/#use_directory_urls
+
 # Configuration
 theme:
   name: material
@@ -28,6 +30,7 @@ theme:
   include_search_page: false
   search_index_only: true
   include_homepage_in_sidebar: false
+  
 
   # Static files
   static_templates:


### PR DESCRIPTION
Signed-off-by: samzong.lu <samzong.lu@gmail.com>

优化文档结尾 `/` 的使用问题，根据 Issue #1876 提出的问题分析，

这是因为 `mkdocs` 在处理 md>html 时，如果在路径 `xxx` 之后加上 `/` 无法判断时会跳转到失败页面，一般依赖文件夹下有 index.md 或者 readme.md

```yaml
use_directory_urls: false # disbale https://www.mkdocs.org/user-guide/configuration/#use_directory_urls
```
use_directory_urls 是在构建文件时是否已目录为结尾，默认是启用，本次 PR 的目的是关闭此配置

效果如下：

Source file | use_directory_urls: true | use_directory_urls: false
-- | -- | --
index.md | / | /index.html
api-guide.md | /api-guide/ | /api-guide.html
about/license.md | /about/license/ | /about/license.html

在现有文档站中

```yaml
- Old: https://docs.daocloud.io/install/install-tools/  #隐含了 index.html
- New: https://docs.daocloud.io/install/install-tools.html
```

此次升级不会导致原路径失效，但会优化文档站内部路由；且 **可有效解决使用 CDN 缓存导致的网页内容更新不及时问题**