### PR TITLE
Fix links in community index

### DIFF
--- a/docs/en/docs/community/index.md
+++ b/docs/en/docs/community/index.md
@@ -170,7 +170,7 @@
 <p align="center">
 <img src="https://landscape.cncf.io/images/left-logo.svg" width="150"/>&nbsp;&nbsp;<img src="https://landscape.cncf.io/images/right-logo.svg" width="200"/>
 <br/><br/>
-[Clusterpedia](./clusterpedia.md), [HwameiStor](./hwameistor.md) and [Merbridge](./merbridge.md) have been listed in <a href="https://www.cncf.io/projects/clusterpedia/">CNCF Sandbox</a>.
+Clusterpedia, HwameiStor, and Merbridge have been selected for the <a href="https://www.cncf.io/projects/clusterpedia/">CNCF Sandbox</a>.
 </p>
 
 [Download DCE 5.0](../download/index.md){ .md-button .md-button--primary }


### PR DESCRIPTION
Remove links here and remain text only.

<img width="885" alt="image" src="https://github.com/DaoCloud/DaoCloud-docs/assets/79828097/e5bea621-3188-465c-aeef-893727baa21e">
