### PR TITLE
download: rabbitmq version updated to v0.13.1

### DIFF
--- a/docs/zh/docs/download/index.md
+++ b/docs/zh/docs/download/index.md
@@ -67,7 +67,7 @@ DCE 5.0 还提供了各种精选中间件：
 | MongoDB       | 296.23 MB | [:arrow_right: 下载页](./modules/middleware/mongodb.md)       | 2023-10-11 |
 | MySQL  |1.17 GB| [:arrow_right: 下载页](./modules/middleware/mysql.md) |2023-10-12|
 | PostgreSQL    | 296.23 MB | [:arrow_right: 下载页](./modules/middleware/postgresql.md)    | 2023-10-11 |
-| RabbitMQ      | 296.23 MB | [:arrow_right: 下载页](./modules/middleware/rabbitmq.md)      | 2023-10-11 |
+| RabbitMQ |162.34MB| [:arrow_right: 下载页](./modules/middleware/rabbitmq.md) |2023-10-12|
 | Redis         | 296.23 MB | [:arrow_right: 下载页](./modules/middleware/redis.md)         | 2023-10-11 |
 
 !!! note

--- a/docs/zh/docs/download/modules/middleware/rabbitmq.md
+++ b/docs/zh/docs/download/modules/middleware/rabbitmq.md
@@ -6,7 +6,7 @@
 
 | 版本                                                         | 架构 | 文件大小 | 安装包                                                                                                                             |  校验文件 | 更新日期       |
 |------------------------------------------------------------| ----- |-------- |---------------------------------------------------------------------------------------------------------------------------------| ---------- |------------|
-| [v0.13.1](../../../middleware/rabbitmq/release-notes.md)      | AMD 64 | 296.23MB | [:arrow_down: rabbitmq_0.13.1_amd64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/rabbitmq_0.13.1_amd64.tar) | [:arrow_down: rabbitmq_0.13.1_amd64_checksum.sha512sum](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/rabbitmq_0.13.1_amd64_checksum.sha512sum) | 2023-10-10 |
+| [v0.13.1](../../../middleware/rabbitmq/release-notes.md) | AMD 64 | 162.34MB | [:arrow_down: rabbitmq_0.13.1_amd64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/rabbitmq_0.13.1_amd64.tar) | [:arrow_down: rabbitmq_0.13.1_amd64_checksum.sha512sum](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/rabbitmq_0.13.1_amd64_checksum.sha512sum) | 2023-10-12 |
 
 ## 校验
 


### PR DESCRIPTION
download: rabbitmq version updated to v0.13.1