### PR TITLE
[en]: add container-engine-install in kant/user-guide

### DIFF
--- a/docs/en/docs/kant/user-guide/node/container-engine-install.md
+++ b/docs/en/docs/kant/user-guide/node/container-engine-install.md
@@ -1,0 +1,75 @@
+---
+MTPE: WANG0608GitHub
+Date: 2024-08-26
+---
+
+# Install Container Runtime on Edge Nodes
+
+Before edge nodes connect to the system, it is necessary to configure the node environment,
+which includes installing a container runtime. This article describes how to install containerd, a container runtime recommended in kubernetes community.
+
+!!! note
+
+    - If the installed version of KubeEdge is higher than v1.12.0, it is recommended to install containerd.
+    - For KubeEdge v1.15.0 and above, please install containerd v1.6.0 or higher.
+
+## Install containerd
+
+To integrate an Edge node requires some CNI plugins, so it is recommended to directly install containerd with CNI plugins. The steps are as follows:
+
+1. Download containerd installation package and upload it to the edge node. See [download link](https://github.com/containerd/containerd/tags)
+   and select the appropriate version of the installation package based on the operating system and
+   CPU architecture of the edge node.
+
+2. Unpack the installation package to the root directory.
+
+    ```shell
+    tar xvzf {installation_package_name} -C /
+    ```
+
+3. Generate the containerd configuration file.
+
+    ```shell
+    mkdir /etc/containerd
+    containerd config default > /etc/containerd/config.toml
+    ```
+
+4. Start containerd.
+
+    ```shell
+    systemctl start containerd && systemctl enable containerd
+    ```
+
+5. Verify whether containerd is successfully installed and running.
+
+    ```shell
+    systemctl status containerd
+    ```
+
+## Install the nerdctl tool (optional)
+
+It is recommended to install the nerdctl command-line tool for easier container operation
+and debugging on the node. The steps are as follows:
+
+1. Download the nerdctl installation package and upload it to the edge node. See [download page](https://github.com/containerd/nerdctl/releases).
+
+    !!! note
+
+        Please select the appropriate installation package based on the operating system and CPU architecture. Install nerdctl v1.7.0 or higher.
+
+2. Unpack the installation package and copy the binary file to the **/usr/local/bin** directory.
+
+    ```shell
+    tar -zxvf nerdctl-1.7.6-linux-amd64.tar.gz
+    cd nerdctl-1.7.6-linux-amd64
+    cp nerdctl /usr/local/bin
+    ```
+
+3. Verify that containerd is successfully installed.
+
+    Use the following command to check the nerdctl version. If it is displayed correctly,
+    it indicates that nerdctl has been successfully installed.
+
+    ```shell
+    nerdctl version
+    ```

--- a/docs/en/navigation.yml
+++ b/docs/en/navigation.yml
@@ -1176,6 +1176,7 @@ nav:
               - Edge Node:
                   - Overview: kant/user-guide/node/index.md
                   - Requirements to Join Edge Node: kant/user-guide/node/join-rqmt.md
+                  - Install Container Runtime on Edge Nodes: kant/user-guide/node/container-engine-install.md
                   - Create Integration Guide: kant/user-guide/node/create-access-guide.md
                   - Edge Node Onboarding: kant/user-guide/node/access-guide.md
                   - Manage Edge Nodes: kant/user-guide/node/manage-node.md

--- a/docs/zh/docs/kant/user-guide/node/container-engine-install.md
+++ b/docs/zh/docs/kant/user-guide/node/container-engine-install.md
@@ -1,17 +1,17 @@
 # 边缘节点安装容器引擎
 
-边缘节点在接入系统之前，需要先配置节点环境，其中就包括安装容器引擎。本文介绍如何安装容器运行时组件 Containerd.
+边缘节点在接入系统之前，需要先配置节点环境，其中就包括安装容器引擎。本文介绍如何安装容器运行时组件 containerd.
 
 !!! note
 
-    - 如果您安装的 KubeEdge 版本高于 v1.12.0，推荐安装 Containerd。
-    - KubeEdge v1.15.0以及以上版本，请安装 v1.6.0 或更高版本的 Containerd。
+    - 如果您安装的 KubeEdge 版本高于 v1.12.0，推荐安装 containerd。
+    - KubeEdge v1.15.0以及以上版本，请安装 v1.6.0 或更高版本的 containerd。
 
-## 安装 Containerd
+## 安装 containerd
 
-边缘节点接入需要依赖 CNI 插件，所以建议直接安装带有 CNI 插件的 Containerd，操作步骤如下：
+边缘节点接入需要依赖 CNI 插件，所以建议直接安装带有 CNI 插件的 containerd，操作步骤如下：
 
-1. 下载 Containerd 安装包并上传到边缘节点，前往[下载地址](https://github.com/containerd/containerd/tags)，根据边缘节点操作系统以及 CPU 架构选择对应版本安装包。
+1. 下载 containerd 安装包并上传到边缘节点，前往[下载地址](https://github.com/containerd/containerd/tags)，根据边缘节点操作系统以及 CPU 架构选择对应版本安装包。
 
 2. 将安装包解压到根目录。
 
@@ -19,7 +19,7 @@
     tar xvzf {安装包名称} -C /
     ```
 
-3. 生成 Containerd 配置文件。
+3. 生成 containerd 配置文件。
 
     !!! note
 
@@ -30,13 +30,13 @@
     containerd config default > /etc/containerd/config.toml
     ```
 
-4. 启动 Containerd。
+4. 启动 containerd。
 
     ```shell
     systemctl start containerd && systemctl enable containerd
     ```
 
-5. 验证 Containerd 是否安装成功并且成功运行。
+5. 验证 containerd 是否安装成功并且成功运行。
 
     ```shell
     systemctl status containerd
@@ -60,9 +60,9 @@
     cp nerdctl /usr/local/bin
     ```
 
-3. 验证 Containerd 是否安装成功。
+3. 验证 containerd 是否安装成功。
 
-    使用如下命令查看 Server 版本号，若果能正常显示，说明 nerdctl 已经成功安装。
+    使用如下命令查看 Server 版本号，如果能正常显示，说明 nerdctl 已经成功安装。
 
     ```shell
     nerdctl version


### PR DESCRIPTION
Update a new page after #5329