### PR TITLE
update install to v0.25.0

### DIFF
--- a/docs/zh/docs/install/commercial/start-install.md
+++ b/docs/zh/docs/install/commercial/start-install.md
@@ -15,13 +15,13 @@
 
 | CPU 架构 | 版本 | 点击下载 |
 | :------- | :----- | :-----|
-| AMD64 | v0.24.0 | [offline-v0.24.0-amd64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/offline-v0.24.0-amd64.tar) |
-| <font color="green">ARM64</font> | v0.24.0 | [offline-v0.24.0-arm64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/offline-v0.24.0-arm64.tar) |
+| AMD64 | v0.25.0 | [offline-v0.25.0-amd64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/offline-v0.25.0-amd64.tar) |
+| <font color="green">ARM64</font> | v0.25.0 | [offline-v0.25.0-arm64.tar](https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/offline-v0.25.0-arm64.tar) |
 
 下载完毕后解压离线包。以 amd64 架构离线包为例：
 
 ```bash
-tar -xvf offline-v0.24.0-amd64.tar
+tar -xvf offline-v0.25.0-amd64.tar
 ```
 
 ### ISO 操作系统镜像文件（必需）

--- a/docs/zh/docs/install/community/k8s/k8s-dce-deploy.md
+++ b/docs/zh/docs/install/community/k8s/k8s-dce-deploy.md
@@ -22,7 +22,7 @@
 - CRI：containerd（因为新版本 K8s 已经不再直接支持 Docker）
 - CNI：Calico
 - StorageClass：local-path
-- DCE 5.0 社区版：v0.24.0
+- DCE 5.0 社区版：v0.25.0
 
 ## 准备节点
 
@@ -334,7 +334,7 @@ bash install_prerequisite.sh online community
 ### 下载 dce5-installer
 
 ```bash
-export VERSION=v0.24.0
+export VERSION=v0.25.0
 curl -Lo ./dce5-installer https://proxy-qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/dce5-installer-$VERSION
 chmod +x ./dce5-installer 
 ```

--- a/docs/zh/docs/install/community/k8s/offline.md
+++ b/docs/zh/docs/install/community/k8s/offline.md
@@ -27,10 +27,10 @@
 
 1. 先找一台能连通外网的机器，运行以下命令下载社区版离线包并解压（也可以从网页[下载中心](../../../download/index.md)下载离线包并解压）：
 
-    假定版本 VERSION=v0.24.0
+    假定版本 VERSION=v0.25.0
 
     ```bash
-    export VERSION=v0.24.0
+    export VERSION=v0.25.0
     wget https://qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/offline-community-$VERSION-amd64.tar
     tar -xvf offline-community-$VERSION-amd64.tar
     ```

--- a/docs/zh/docs/install/community/k8s/online.md
+++ b/docs/zh/docs/install/community/k8s/online.md
@@ -28,10 +28,10 @@
 
 1. 在 K8s 集群控制平面节点（Controller Node）下载 dce5-installer 二进制文件（也可以[通过浏览器下载](../../../download/index.md)）。
 
-    假定 VERSION 为 v0.24.0
+    假定 VERSION 为 v0.25.0
 
     ```shell
-    export VERSION=v0.24.0
+    export VERSION=v0.25.0
 
     # 如果是 ARM 架构请更新 `dce5-installer-$VERSION` 为 `dce5-installer-$VERSION-linux-arm64`
     

--- a/docs/zh/docs/install/community/kind/online.md
+++ b/docs/zh/docs/install/community/kind/online.md
@@ -162,10 +162,10 @@ precheck pass..
 
 1. 在 kind 主机下载 dce5-installer 二进制文件。
 
-    假定 VERSION 为 v0.24.0
+    假定 VERSION 为 v0.25.0
 
     ```shell
-    export VERSION=v0.24.0
+    export VERSION=v0.25.0
     curl -Lo ./dce5-installer https://proxy-qiniu-download-public.daocloud.io/DaoCloud_Enterprise/dce5/dce5-installer-$VERSION
     chmod +x ./dce5-installer
     ```


### PR DESCRIPTION
还缺这一节的离线包：

```markdown
### osPackage 离线包（必需）

=== "V0.24.0"

    | 操作系统版本 | 点击下载 |
    | :--------- | :------ |
    | CentOS 7     | [os-pkgs-centos7-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-centos7-v0.21.1.tar.gz) |
    | Redhat 8     | [os-pkgs-redhat8-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-redhat8-v0.21.1.tar.gz) |
    | Redhat 7     | [os-pkgs-redhat7-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-redhat7-v0.21.1.tar.gz) |
    | Redhat 9     | [os-pkgs-redhat9-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-redhat9-v0.21.1.tar.gz) |
    | Ubuntu 20.04  | [os-pkgs-ubuntu2004-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-ubuntu2004-v0.21.1.tar.gz) |
    | Ubuntu 22.04  | [os-pkgs-ubuntu2204-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-ubuntu2204-v0.21.1.tar.gz) |
    | openEuler 22.03 | [os-pkgs-openeuler22.03-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-openeuler22.03-v0.21.1.tar.gz) |
    | Oracle Linux R9 U1 | [os-pkgs-oracle9-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-oracle9-v0.21.1.tar.gz) |
    | Oracle Linux R8 U7 | [os-pkgs-oracle8-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-oracle8-v0.21.1.tar.gz) |
    | Rocky Linux 9.2 | [os-pkgs-rocky9-v0.21.1.tar.gz](https://github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-rocky9-v0.21.1.tar.gz) |
    | Rocky Linux 8.10 | [os-pkgs-rocky8-v0.21.1.tar.gz](https://github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-rocky8-v0.21.1.tar.gz) |
    | Kylin Linux Advanced Server release V10 (Sword) SP2 | [os-pkgs-kylinv10-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-kylin-v10sp2-v0.21.1.tar.gz) |
    | Kylin Linux Advanced Server release V10 (Halberd) SP3 | [os-pkgs-kylinv10sp3-v0.21.1.tar.gz](https://files.m.daocloud.io/github.com/kubean-io/kubean/releases/download/v0.21.1/os-pkgs-kylin-v10sp3-v0.21.1.tar.gz) |
```
cc @samzong 