### PR TITLE
CI: improve PR creation logic for auto generate release-notes

### DIFF
--- a/.github/workflows/call-update-release-notes.yaml
+++ b/.github/workflows/call-update-release-notes.yaml
@@ -64,21 +64,18 @@ jobs:
           REPO_NAME: ${{ env.repo_name }}
         run: |
           set -x
-          if ! [[ -n "$(git status --porcelain)" ]]; then
-            echo "changes=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
+          set -e
           # Check if there are already open PRs for this project's release notes
           # Look for PRs that match both the title pattern and have the 'documentation' label
           existing_prs=$(gh pr list --repo ${{ github.repository }} --json title,labels,headRefName --jq '.[] | select(.title == "docs: auto update '"$REPO_NAME"' release notes" and (.labels | map(.name) | contains(["auto-sync-release-notes"]))) | .headRefName')
-
+          echo "DEBUG: existing_prs value: '$existing_prs'"
           if [[ -n "$existing_prs" ]]; then
             echo "Found existing auto-generated PRs for $REPO_NAME release notes. Skipping PR creation."
             echo "changes=false" >> $GITHUB_OUTPUT
-            exit 0
+          else
+            echo "No existing auto-generated PRs found for $REPO_NAME release notes. Creating PR."
+            echo "changes=true" >> $GITHUB_OUTPUT
           fi
-          echo "changes=true" >> $GITHUB_OUTPUT
 
       - name: Update release notes
         if: steps.check_changes.outputs.changes == 'true'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -86,14 +86,31 @@ if [ -z "$PROJECT_ZH_RELEASE_NOTES_PATH" ]; then
 fi
 
 # Create release-notes directory if it doesn't exist
-RELEASE_NOTES_DIR="${PROJECT_EN_RELEASE_NOTES_PATH}/release-notes"
+RELEASE_NOTES_DIR="${PROJECT_EN_RELEASE_NOTES_PATH}"
 mkdir -p "$RELEASE_NOTES_DIR"
 
 # Function to fetch release notes for a specific tag
 fetch_release_notes() {
     local tag=$1
-    sub_path=$(echo $tag | tr '.' '')
-    local output_file="$RELEASE_NOTES_DIR/${sub_path}.md"
+
+    # Extract major.minor version from the tag
+    # Remove 'v' prefix if present
+    local version=${tag#v}
+
+    # Extract major and minor version numbers
+    local major_minor=$(echo "$version" | grep -oE '^[0-9]+\.[0-9]+')
+
+    if [ -z "$major_minor" ]; then
+        echo "Warning: Could not extract major.minor version from tag: $tag"
+        # Fallback to using the tag directly
+        major_minor="$version"
+    fi
+
+    # Create directory for this major.minor version
+    local version_dir="$RELEASE_NOTES_DIR/release-$major_minor"
+    mkdir -p "$version_dir"
+
+    local output_file="$version_dir/${tag}.md"
 
     echo "Fetching release notes for tag: $tag"
 


### PR DESCRIPTION
- 修复 release-notes CI 未触发的问题，之前会检测是否当前已存在但未处理的 PR，如果有则不创建
- 规范生成 Release-notes 的路径，对于 x.y.x 格式的 tag，x.y.* 都会放到 release-x.y 路径下

参考 https://github.com/cyclinder/github-ci/pull/52