### PR TITLE
[en] Update a command in amamba/intro/index.md

### DIFF
--- a/docs/en/docs/amamba/intro/index.md
+++ b/docs/en/docs/amamba/intro/index.md
@@ -74,7 +74,7 @@ However, if you want to install or upgrade the Workbench module separately, run 
 ```bash
 export VERSION=**** # (1)!
 helm repo add amamba-release https://release.daocloud.io/chartrepo/amamba
-helm repo update amamba
+helm repo update amamba-release
 helm upgrade --install --create-namespace --cleanup-on-fail amamba amamba-release/amamba -n amamba-system --version=${VERSION}
 ```
 


### PR DESCRIPTION
Fixed the helm repo update command so it can match the repo name in the previous command. The zh version has been fixed in the last pr, this one is for en version.

Follow #6755 