### PR TITLE
Remove API call example image from documentation

### DIFF
--- a/docs/zh/docs/ghippo/user-guide/report-billing/report-recalculation.md
+++ b/docs/zh/docs/ghippo/user-guide/report-billing/report-recalculation.md
@@ -28,8 +28,6 @@ curl -X POST \
   "http://<api-address>/apis/gmagpie.io/v1alpha1/report/recalculate"
 ```
 
-![API 调用示例](../images/report-recalc-api.png)
-
 ### 2. 任务处理逻辑
 
 系统接收请求后会在后台按序处理：


### PR DESCRIPTION
Removed API call example image from the report recalculation documentation.因为没有那张图片了，上面的代码已经可以说明问题了