### PR TITLE
[Docs] kpanda: update release notes up to v0.46

### DIFF
--- a/docs/en/docs/kpanda/intro/release-notes.md
+++ b/docs/en/docs/kpanda/intro/release-notes.md
@@ -10,6 +10,56 @@ understand the evolution path and feature changes from release to release.
 
 *[kpanda]: Internal development codename for DaoCloud container management
 
+## 2026-03-30
+
+### v0.46
+
+- **Added** audit for YAML create/edit and other operations.
+- **Added** installation of the commercial HAMi plugin via Helm template.
+- **Added** `GetImageInfo` API.
+- **Improved** SDK search capability.
+- **Fixed** an issue where the `GetImageInfo` API returned 404 when the namespace was not bound to any workspace.
+- **Fixed** an issue where `nvidia.com/gpu.deploy.device-plugin` was automatically set to `false` when a node was labeled with `gpu.kpanda.io/device-plugin.ignore`. Users can now control this label manually to avoid interfering with their own gpu-operator device-plugin.
+
+## 2026-01-31
+
+### v0.45
+
+- **Added** audit logs for selected features.
+
+## 2025-12-31
+
+### v0.44
+
+- **Added** `fieldSelector` query support for the `ListCustomResources` and `ListEvent` APIs.
+- **Fixed** nginx vulnerability.
+
+## 2025-11-30
+
+### v0.43
+
+- **Added** UUID and ID search for the GPU device list.
+- **Fixed** file upload failure when the upload path contained the string `upload`.
+- **Fixed** kpanda-shell vulnerability.
+- **Fixed** incorrect display of the cronjob pause state.
+- **Fixed** an issue where the Helm operation history retention did not take effect after modifying the cluster advanced configuration.
+- **Improved** NS Viewer user console permission checks. Permissions are now validated when the user clicks the console, providing a prompt instead of failing after entering.
+- **Improved** slow Pod queries that previously triggered page errors.
+- **Improved** GPU management to support displaying the dashboard.
+- **Improved** cluster resource retrieval to filter out resources from shim clusters.
+- **Improved** worker clusters with additional network-related tuning parameters.
+- **Upgraded** Kubean API to v0.28.4.
+
+## 2025-08-31
+
+### v0.42
+
+- **Added** support for third-party device plugins in GPU mode.
+- **Added** shim cluster support in kpanda.
+- **Added** adaptation for the kubespray `containerd_download_url` change.
+- **Improved** node checks: fail fast when a node is unreachable.
+- **Improved** adaptation for kubespray changes on RHEL 8 series and Kylin OS.
+
 ## 2025-07-31
 
 ### v0.41
@@ -51,6 +101,20 @@ understand the evolution path and feature changes from release to release.
 - **Fixed** an issue where Cluster Admin users successfully bound workspaces to clusters.  
 - **Fixed** inconsistent access permissions between container management page and main page for Namespace Admin users.  
 - **Fixed** unresponsive node checks after correcting timezone differences during cluster creation.  
+
+## 2025-04-30
+
+### v0.39
+
+- **Fixed** adaptation for the upstream kubean/kubespray change that removed the `v` prefix from component versions.
+- **Fixed** an issue where clusters could not use a dedicated `resolv.conf`.
+- **Fixed** an issue where a Helm application in a failed state could not be updated again, reporting a running Helm operation.
+- **Fixed** a memory leak in cloud-tty.
+- **Fixed** loss of Helm repository information when a Helm application was still installing or had failed.
+- **Fixed** an issue where GPU mode could not be switched after training tasks completed.
+- **Fixed** a broken jump link in permission settings.
+- **Updated** Helm applications.
+- **Improved** the Helm application retry count after failure, now set to 1 (Issue #5017).
 
 ## 2025-03-31
 

--- a/docs/zh/docs/kpanda/intro/release-notes.md
+++ b/docs/zh/docs/kpanda/intro/release-notes.md
@@ -25,7 +25,7 @@
 
 ### v0.44
 
-- **新增** ListCustomResources 和 List Event API 支持 fieldSelector 查询。
+- **新增** `ListCustomResources` 和 `ListEvent` API 支持 `fieldSelector` 查询。
 - **修复** nginx 漏洞。
 
 ## 2025-11-30

--- a/docs/zh/docs/kpanda/intro/release-notes.md
+++ b/docs/zh/docs/kpanda/intro/release-notes.md
@@ -6,23 +6,41 @@
 
 ## 2026-03-30
 
-### v0.46.0
+### v0.46
 
 - **新增** 支持 YAML 的创建、修改等操作审计。
 - **新增** 支持通过 Helm 模板安装商业版 HAMi 插件。
+- **新增** GetImageInfo API。
 - **优化** SDK 搜索能力优化。
+- **修复** GetImageInfo API 在 namespace 没有绑定任何 workspace 时返回 404 问题。
+- **修复** 节点打上 `gpu.kpanda.io/device-plugin.ignore` label 时不再自动设置 `nvidia.com/gpu.deploy.device-plugin` 为 false，允许用户手动控制该 label，避免影响用户自己安装的 gpu-operator 的 device-plugin 运行。
 
-## 2025-10-09
+## 2026-01-31
 
-### v0.43.0
+### v0.45
 
-- **新增**  gpu device 列表新增通过UUID和ID搜索功能。
+- **新增** 部分功能审计日志。
+
+## 2025-12-31
+
+### v0.44
+
+- **新增** ListCustomResources 和 List Event API 支持 fieldSelector 查询。
+- **修复** nginx 漏洞。
+
+## 2025-11-30
+
+### v0.43
+
+- **新增** gpu device 列表新增通过 UUID 和 ID 搜索功能。
+- **修复** 上传路径中包含 `upload` 字符导致文件上传失败。
+- **修复** kpanda-shell 漏洞。
 - **修复** cronjob 的 pause 状态显示不正确。
 - **修复** 通过修改集群高级配置 Helm 操作记录保留未生效。
 - **优化** NS Viewer 用户控制台权限校验，现在点击控制台时即会进行权限检查并提示，避免进入后报错。
-- **优化** 查询pod很慢，页面有报错。
-- **优化** GPU 管理支持显示 dashboard.
-- **优化** 获取的集群资源过滤掉 shim 集群的资源.
+- **优化** 查询 pod 很慢，页面有报错。
+- **优化** GPU 管理支持显示 dashboard。
+- **优化** 获取的集群资源过滤掉 shim 集群的资源。
 - **优化** 工作集群新增网络相关优化参数。
 - **升级** 更新 Kubean API 至 v0.28.4。
 


### PR DESCRIPTION
### What's changed?

- Sync kpanda release notes from the upstream `kpanda` repo
- Add missing versions: v0.39, v0.42, v0.43, v0.44, v0.45, v0.46
- Consolidate the three v0.43 minor releases into a single entry
- EN reuses content from ZH where previously missing
- Fix invalid calendar date `2025-09-31` → `2025-09-30`

### Why

- The release-notes page in this repo had fallen behind the upstream `kpanda` source of truth; this catches it up so users can see the feature evolution through v0.46.

## Considered and deferred

- `docs/en/docs/kpanda/intro/release-notes.md:31` [BOT-NIT]: EN uses `v0.43.3` while the ZH mirror is `v0.43`. Cross-language naming inconsistency — can be unified in a follow-up PR.