### PR TITLE
fix: Clean up HTML tags in ethplan.md

### DIFF
--- a/docs/en/docs/network/plans/ethplan.md
+++ b/docs/en/docs/network/plans/ethplan.md
@@ -14,8 +14,8 @@ When the application Pod in the cluster only needs to use a single CNI and does 
 
 | Deployment Environment | Infrastructure | Number of NICs | NIC Description | Purpose |
 | -------------- | ----------------- | ---------------- - | ----------------------- | ------------- |
-| PoC environment<br /> | Physical machine<br />Virtual machine<br />Public cloud| 1 physical network card/Bond network card| Access mode access, the network card where the default route is located ==[^1]== | Bearer K8s management traffic, Calico Pod traffic |
-| Production environment<br /> | Physical machine<br />Virtual machine<br />Public cloud| 1 or 2 physical network cards/Bond network cards| **NIC 1**: Access mode access, the network card where the default route is located< br />**NIC 2** ==[^2]== (optional): Access mode access | **NIC 1**: carry K8s management traffic, Calico Pod traffic<br />**NIC 2**: Hwameistor data replicas synchronize traffic across nodes |
+| PoC environment<br/> | Physical machine<br/>Virtual machine<br/>Public cloud| 1 physical network card/Bond network card| Access mode access, the network card where the default route is located ==[^1]== | Bearer K8s management traffic, Calico Pod traffic |
+| Production environment<br/> | Physical machine<br/>Virtual machine<br/>Public cloud| 1 or 2 physical network cards/Bond network cards| **NIC 1**: Access mode access, the network card where the default route is located**NIC 2** ==[^2]== (optional): Access mode access | **NIC 1**: carry K8s management traffic, Calico Pod traffic<br/>**NIC 2**: Hwameistor data replicas synchronize traffic across nodes |
 
 ## Overlay + Underlay scheme
 
@@ -23,9 +23,10 @@ When the cluster deployment application needs to use a combination of multiple C
 
 | Deployment Environment | Infrastructure | Number of NICs | NIC Description | Purpose |
 | -------------- | ----------------- | ---------------- - | ----------------------- | ------------- |
-| PoC environment| Physical machine<br />Virtual machine<br /> | 1 physical network card / Bond network card | Access mode access, the network card where the default route is ==[^1]== | Carrying K8s management traffic, Calico Pod Traffic, Underlay CNI (Macvlan) Pod Traffic |
-| Production environment<br /> | Physical machine<br />Virtual machine<br /> | 2 physical NICs/Bond NICs| **NIC 1**: Access mode access, the network card where the default route is located<br />**NIC 2** ==[^1]==: Trunk mode access | **NIC 1**: carrying K8s management traffic, Calico Pod traffic<br />**NIC 2**: carrying Underlay CNI (Macvlan/SR-IOV) Pod Traffic |
-| Production environment<br /> | Physical machine<br />Virtual machine<br /> | 3 physical network cards/Bond network cards| **NIC 1**: Access mode access, the network card where the default route is located<br />**NIC 2** ==[^2]==: Trunk mode access<br />**NIC 3** (optional): Access mode access| **NIC 1**: carrying K8s management traffic, Calico Pod traffic<br />**NIC 2**: carrying Underlay CNI (Macvlan/SR-IOV) Pod traffic<br />**NIC 3**: Hwameistor data copy cross-node synchronization traffic |
+| PoC environment| Physical machine<br/>Virtual machine<br/> | 1 physical network card / Bond network card | Access mode access, the network card where the default route is ==[^1]== | Carrying K8s management traffic, Calico Pod Traffic, Underlay CNI (Macvlan) Pod Traffic |
+| Production environment<br/> | Physical machine<br/>Virtual machine<br/> | 2 physical NICs/Bond NICs| **NIC 1**: Access mode access, the network card where the default route is located<br/>**NIC 2** ==[^1]==: Trunk mode access | **NIC 1**: carrying K8s management traffic, Calico Pod traffic<br/>**NIC 2**: carrying Underlay CNI (Macvlan/SR-IOV) Pod Traffic |
+| Production environment<br/> | Physical machine<br/>Virtual machine<br/> | 3 physical network cards/Bond network cards| **NIC 1**: Access mode access, the network card where the default route is located<br/>**NIC 2** ==[^2]==: Trunk mode access<br/>**NIC 3** (optional): Access mode access| **NIC 1**: carrying K8s management traffic, Calico Pod traffic<br/>**NIC 2**: carrying Underlay CNI (Macvlan/SR-IOV) Pod traffic<br/>**NIC 3**: Hwameistor data copy cross-node synchronization traffic |
 
 [^1]: All network cards shall have a consistent name
 [^2]: All network cards shall have a consistent name; if you want to use Hwameistor local storage and enable the high availability function, you can plan additional network cards based on actual situations
+


### PR DESCRIPTION
修复以下问题:
- 统一 <br /> 为 <br/>
- 移除损坏的 < br /> 标签

来自 OpenClaw 文档检查工具的自动修复。