### PR TITLE
fix: Correct image paths in ZH docs

### DIFF
--- a/docs/zh/docs/ghippo/user-guide/access-control/user.md
+++ b/docs/zh/docs/ghippo/user-guide/access-control/user.md
@@ -15,11 +15,11 @@
 
 1. 管理员进入 __用户与访问控制__ ，选择 __用户__ ，进入用户列表，点击右上方的 __创建用户__ 。
 
-    ![创建用户按钮](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/createuser01.png)
+    ![创建用户按钮](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/createuser01.png)
 
 2. 在 __创建用户__ 页面填写用户名和登录密码。如需一次性创建多个用户，可以点击 __创建用户__ 后进行批量创建，一次性最多创建 5 个用户。根据您的实际情况确定是否设置用户在首次登录时重置密码。
 
-    ![设置用户名和密码](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/createuser02.png)
+    ![设置用户名和密码](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/createuser02.png)
 
 3. 点击 __确定__ ，创建用户成功，返回用户列表页。
 
@@ -33,11 +33,11 @@
 
 1. 管理员进入 __用户与访问控制__ ，选择 __用户__ ，进入用户列表，点击 __┇__ -> __授权__ 。
 
-    ![授权菜单](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/authorize01.png)
+    ![授权菜单](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/authorize01.png)
 
 2. 在 __授权__ 页面勾选需要的角色权限（可多选）。
 
-    ![授权界面](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/authorize02.png)
+    ![授权界面](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/authorize02.png)
 
 3. 点击 __确定__ 完成为用户的授权。
 
@@ -49,11 +49,11 @@
 
 1. 管理员进入 __用户与访问控制__ ，选择 __用户__ ，进入用户列表，点击 __┇__ -> __加入用户组__ 。
 
-    ![加入用户组菜单](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/joingroup01.png)
+    ![加入用户组菜单](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/joingroup01.png)
 
 2. 在 __加入用户组__ 页面勾选需要加入的用户组（可多选）。若没有可选的用户组，点击 __创建用户组__ 创建用户组，再返回该页面点击 __刷新__ 按钮，显示刚创建的用户组。
 
-    ![加入用户组界面](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/joingroup02.png)
+    ![加入用户组界面](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/joingroup02.png)
 
 3. 点击 __确定__ 将用户加入用户组。
 
@@ -67,11 +67,11 @@
 
 1. 管理员进入 __用户与访问控制__ ，选择 __用户__ ，进入用户列表，点击一个用户名进入用户详情。
 
-    ![用户详情](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/createuser03.png)
+    ![用户详情](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/createuser03.png)
 
 2. 点击右上方的 __编辑__ ，关闭状态按钮，使按钮置灰且处于未启用状态。
 
-    ![编辑](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/enableuser.png)
+    ![编辑](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/enableuser.png)
 
 3. 点击 __确定__ 完成禁用用户的操作。
 
@@ -81,11 +81,11 @@
 
 - 管理员在该用户详情页面，点击 __编辑__ ，在弹出框输入用户邮箱地址，点击 __确定__ 完成邮箱设置。
 
-    ![编辑](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/enableuser.png)
+    ![编辑](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/enableuser.png)
 
 - 用户还可以进入 __个人中心__ ，在 __安全设置__ 页面设置邮箱地址。
 
-    ![个人中心](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/mailbox.png)
+    ![个人中心](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/mailbox.png)
 
 如果用户登录时忘记密码，请参考[重置密码](../password.md)。
 
@@ -100,11 +100,11 @@
 
 1. 管理员进入 __用户与访问控制__ ，选择 __用户__ ，进入用户列表，点击 __┇__ -> __删除__ 。
 
-    ![删除用户菜单](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/deleteuser01.png)
+    ![删除用户菜单](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/deleteuser01.png)
 
 2. 点击 __移除__ 完成删除用户的操作。
 
-    ![删除用户确认](https://docs.daocloud.io/daocloud-docs-images/docs/ghippo/images/deleteuser02.png)
+    ![删除用户确认](https://docs.daocloud.io/daocloud-docs-images/docs/en/docs/ghippo/images/deleteuser02.png)
 
 
 ## 重置用户双因子认证
@@ -114,3 +114,4 @@
 ![重置用户双因子认证](../../images/2fa03.png)
 
 重置后该用户登录时，需要重新扫码获取新的双因子认证。
+


### PR DESCRIPTION
Fix image paths in ZH docs - add /en/docs/ after /docs/:
- zh/docs/kpanda/user-guide/clusters/create-cluster.md
- zh/docs/ghippo/user-guide/access-control/user.md