### PR TITLE
update redhat8 elfutils-libelf-devel download url

### DIFF
--- a/docs/en/docs/kpanda/user-guide/gpu/nvidia/upgrade_yum_source_redhat8_4.md
+++ b/docs/en/docs/kpanda/user-guide/gpu/nvidia/upgrade_yum_source_redhat8_4.md
@@ -74,7 +74,7 @@ Perform the following steps on a node with internet access. Before proceeding, e
 1. Run the following command on the node with internet access to download the __elfutils-libelf-devel-0.187-4.el8.x86_64.rpm__ package:
 
     ```bash
-    wget https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/elfutils-libelf-devel-0.187-4.el8.x86_64.rpm
+    wget https://dl.rockylinux.org/vault/rocky/8.7/BaseOS/x86_64/os/Packages/e/elfutils-libelf-devel-0.187-4.el8.x86_64.rpm
     ```
 
 2. Transfer the __elfutils-libelf-devel-0.187-4.el8.x86_64.rpm__ package from the current directory to the node mentioned in step 1:

--- a/docs/zh/docs/kpanda/user-guide/gpu/nvidia/upgrade_yum_source_redhat8_4.md
+++ b/docs/zh/docs/kpanda/user-guide/gpu/nvidia/upgrade_yum_source_redhat8_4.md
@@ -80,7 +80,7 @@ DCE 5 预置了 CentOS 7.9，内核为 3.10.0-1160 的 GPU operator 离线包。
 1. 在联网节点执行如下命令，下载 __elfutils-libelf-devel-0.187-4.el8.x86_64.rpm__ 包：
 
     ```bash
-    wget https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/elfutils-libelf-devel-0.187-4.el8.x86_64.rpm
+    wget https://dl.rockylinux.org/vault/rocky/8.7/BaseOS/x86_64/os/Packages/e/elfutils-libelf-devel-0.187-4.el8.x86_64.rpm
     ```
 
 2. 在当前目录下将 __elfutils-libelf-devel-0.187-4.el8.x86_64.rpm__ 包传输至步骤一中的节点上：


### PR DESCRIPTION
Updated the download URL for elfutils-libelf-devel-0.187-4.el8.x86_64.rpm in the GPU Operator offline installation documentation.

The previous CentOS Stream URL was replaced with the Rocky Linux 8.7 Vault URL in both the Chinese and English documents