### PR TITLE
docs: add Microsoft Teams configuration page

### DIFF
--- a/docs/zh/docs/clawos/workspace/teams-info.md
+++ b/docs/zh/docs/clawos/workspace/teams-info.md
@@ -1,0 +1,3 @@
+# Teams 信息
+
+本文档用于记录 Microsoft Teams 集成所需的配置信息。

--- a/docs/zh/navigation.yml
+++ b/docs/zh/navigation.yml
@@ -1301,6 +1301,7 @@ nav:
                       - Skill 管理: clawos/workspace/skill-manage.md
                   - OpenClaw 实例: clawos/workspace/openclaw.md
                   - 飞书集成: clawos/workspace/feishu.md
+                  - Microsoft Teams 配置: clawos/workspace/teams-info.md
               - 管理员视角:
                   - 概览: clawos/admin/overview-admin.md
                   - Skill 管理: clawos/admin/skillmanage-admin.md


### PR DESCRIPTION
## 变更内容

- 新增 Microsoft Teams 配置信息文档。
- 在 ClawOS 工作空间视角导航中加入“Microsoft Teams 配置”。

## 影响范围

- 完善 ClawOS 工作空间文档导航，便于用户访问 Teams 配置说明。

## 校验

- 已执行 `git diff --cached --check`，通过。
