### PR TITLE
docs: add ClawOS upgrade notes

### DIFF
--- a/docs/en/docs/clawos/intro/upgrade-notes.md
+++ b/docs/en/docs/clawos/intro/upgrade-notes.md
@@ -65,9 +65,15 @@ v0.5.3 adds and enables the NetworkPolicy manager by default:
 ```yaml
 manager:
   enabled: true
+  serviceAccount:
+    create: true
 ```
 
-The manager requires access to Kpanda and Clusterpedia, as well as Lease, ConfigMap, and Event permissions. If NetworkPolicy manager is not used in the environment, or its dependencies/API/RBAC are not ready, disable it in the upgrade values:
+The manager requires access to the Kpanda and Clusterpedia services, as well as Lease, ConfigMap, Event, and ClusterPedia resource permissions. When `manager.enabled=true` and `manager.serviceAccount.create=true`, the Chart automatically creates a dedicated ServiceAccount, ClusterRole, and ClusterRoleBinding for the manager; these RBAC resources do not need to be created manually.
+
+During the upgrade, confirm that the identity running Helm can create or update the cluster-scoped ClusterRole and ClusterRoleBinding. If `manager.serviceAccount.create` is set to `false`, provide a ServiceAccount that is already bound to the required permissions. Otherwise, the Helm upgrade may fail, or the manager Pod may not run because of insufficient permissions.
+
+If NetworkPolicy manager is not used in the environment, or the Kpanda/Clusterpedia services are unreachable, disable it in the upgrade values:
 
 ```yaml
 manager:

--- a/docs/en/docs/clawos/intro/upgrade-notes.md
+++ b/docs/en/docs/clawos/intro/upgrade-notes.md
@@ -15,24 +15,21 @@ In v0.5.3, `openclawPrevious` is `2026.6.10`. It is not the target image for upg
 
 !!! note
 
-    Upgrading the AgentClaw Helm Chart only updates the instance template and default image configuration. It does not automatically update existing AgentInstance Deployments. After the upgrade, update or restart each existing instance so that its OpenClaw container uses `2026.7.1`.
-
-Before upgrading, confirm that `release.daocloud.io/agentclaw/openclaw:2026.7.1` is accessible from the environment. If the image cannot be pulled, updated instances will enter `ImagePullBackOff`.
+    After the upgrade, update each existing instance so that its OpenClaw container uses `2026.7.1`.
 
 ### SkillHub configuration
 
-During the upgrade, enable both the ClawOS SkillHub integration and the SkillHub subchart by default:
+SkillHub is disabled by default in v0.5.3. To enable it, set the following values:
 
 ```yaml
 skillhub:
   enabled: true
-  # A node IP or domain reachable when an OpenClaw instance runs npx clawhub install
+  # A node IP or domain reachable by OpenClaw instances when npx clawhub install is run
   publicHost: <reachable cluster node IP or domain>
 
 skillhubChart:
   enabled: true
   secrets:
-    bootstrapAdminPassword: <SkillHub admin password>
     scannerLlmApiKey: <LLM API key>
     scannerLlmBaseUrl: http://<internal model gateway>:<port>/v1
     scannerLlmModel: openai/public/minimax-m25
@@ -46,38 +43,7 @@ skillhubChart:
 
 The following values are important:
 
-- `skillhub.publicHost` must be a node IP or domain reachable when an OpenClaw instance runs `npx clawhub install`. NodePort listens on every cluster node; the master node is not required.
-- `skillhubChart.secrets.scannerLlmApiKey`, `scannerLlmBaseUrl`, `scannerLlmModel`, and `scanner.analyzers.llmProvider` configure LLM analysis for Skill Scanner. Do not commit a real API key to the values file.
+- `skillhub.publicHost` must be a node IP reachable by OpenClaw instances. NodePort listens on every cluster node; the master node is not required.
+- `skillhubChart.secrets.scannerLlmApiKey`, `scannerLlmBaseUrl`, `scannerLlmModel`, and `scanner.analyzers.llmProvider` configure LLM analysis for Skill Scanner.
 - `scannerLlmBaseUrl` must point to an OpenAI-compatible `/v1` endpoint. `scannerLlmModel` uses the LiteLLM route format, such as `openai/public/minimax-m25`.
 - When `useLlm`, `useBehavioral`, and `enableMeta` are all enabled, Scanner combines LLM, behavioral, and meta analysis results.
-
-Before enabling SkillHub, confirm the following:
-
-1. The released AgentClaw Chart package contains the `charts/skillhub` subchart; otherwise Helm dependency rendering fails.
-2. SkillHub, PostgreSQL, Redis, and Scanner images are available in the environment.
-3. A usable StorageClass/PV is available for SkillHub PVCs.
-4. With the default `global.ghippo.applyCR=true`, the cluster has the `ghippo.io/v1alpha1/GProductProxy` CRD. If the CRD is unavailable, set `global.ghippo.applyCR=false`; otherwise Helm deployment fails.
-
-### manager component
-
-v0.5.3 adds and enables the NetworkPolicy manager by default:
-
-```yaml
-manager:
-  enabled: true
-  serviceAccount:
-    create: true
-```
-
-The manager requires access to the Kpanda and Clusterpedia services, as well as Lease, ConfigMap, Event, and ClusterPedia resource permissions. When `manager.enabled=true` and `manager.serviceAccount.create=true`, the Chart automatically creates a dedicated ServiceAccount, ClusterRole, and ClusterRoleBinding for the manager; these RBAC resources do not need to be created manually.
-
-During the upgrade, confirm that the identity running Helm can create or update the cluster-scoped ClusterRole and ClusterRoleBinding. If `manager.serviceAccount.create` is set to `false`, provide a ServiceAccount that is already bound to the required permissions. Otherwise, the Helm upgrade may fail, or the manager Pod may not run because of insufficient permissions.
-
-If NetworkPolicy manager is not used in the environment, or the Kpanda/Clusterpedia services are unreachable, disable it in the upgrade values:
-
-```yaml
-manager:
-  enabled: false
-```
-
-Otherwise, the manager Pod may fail to start or repeatedly restart.

--- a/docs/en/docs/clawos/intro/upgrade-notes.md
+++ b/docs/en/docs/clawos/intro/upgrade-notes.md
@@ -1,0 +1,77 @@
+# Upgrade Notes
+
+This page describes the considerations for upgrading ClawOS from v0.3.3 to v0.5.3.
+
+## Upgrade from v0.3.3 to v0.5.3
+
+### Upgrade images for existing instances
+
+The default OpenClaw instance images are different between v0.3.3 and v0.5.3:
+
+- v0.3.3: `release.daocloud.io/agentclaw/openclaw:2026.4.7`
+- v0.5.3: `release.daocloud.io/agentclaw/openclaw:2026.7.1`
+
+In v0.5.3, `openclawPrevious` is `2026.6.10`. It is not the target image for upgrading existing instances.
+
+!!! note
+
+    Upgrading the AgentClaw Helm Chart only updates the instance template and default image configuration. It does not automatically update existing AgentInstance Deployments. After the upgrade, update or restart each existing instance so that its OpenClaw container uses `2026.7.1`.
+
+Before upgrading, confirm that `release.daocloud.io/agentclaw/openclaw:2026.7.1` is accessible from the environment. If the image cannot be pulled, updated instances will enter `ImagePullBackOff`.
+
+### SkillHub configuration
+
+During the upgrade, enable both the ClawOS SkillHub integration and the SkillHub subchart by default:
+
+```yaml
+skillhub:
+  enabled: true
+  # A node IP or domain reachable when an OpenClaw instance runs npx clawhub install
+  publicHost: <reachable cluster node IP or domain>
+
+skillhubChart:
+  enabled: true
+  secrets:
+    bootstrapAdminPassword: <SkillHub admin password>
+    scannerLlmApiKey: <LLM API key>
+    scannerLlmBaseUrl: http://<internal model gateway>:<port>/v1
+    scannerLlmModel: openai/public/minimax-m25
+  scanner:
+    analyzers:
+      llmProvider: openai
+      useLlm: true
+      useBehavioral: true
+      enableMeta: true
+```
+
+The following values are important:
+
+- `skillhub.publicHost` must be a node IP or domain reachable when an OpenClaw instance runs `npx clawhub install`. NodePort listens on every cluster node; the master node is not required.
+- `skillhubChart.secrets.scannerLlmApiKey`, `scannerLlmBaseUrl`, `scannerLlmModel`, and `scanner.analyzers.llmProvider` configure LLM analysis for Skill Scanner. Do not commit a real API key to the values file.
+- `scannerLlmBaseUrl` must point to an OpenAI-compatible `/v1` endpoint. `scannerLlmModel` uses the LiteLLM route format, such as `openai/public/minimax-m25`.
+- When `useLlm`, `useBehavioral`, and `enableMeta` are all enabled, Scanner combines LLM, behavioral, and meta analysis results.
+
+Before enabling SkillHub, confirm the following:
+
+1. The released AgentClaw Chart package contains the `charts/skillhub` subchart; otherwise Helm dependency rendering fails.
+2. SkillHub, PostgreSQL, Redis, and Scanner images are available in the environment.
+3. A usable StorageClass/PV is available for SkillHub PVCs.
+4. With the default `global.ghippo.applyCR=true`, the cluster has the `ghippo.io/v1alpha1/GProductProxy` CRD. If the CRD is unavailable, set `global.ghippo.applyCR=false`; otherwise Helm deployment fails.
+
+### manager component
+
+v0.5.3 adds and enables the NetworkPolicy manager by default:
+
+```yaml
+manager:
+  enabled: true
+```
+
+The manager requires access to Kpanda and Clusterpedia, as well as Lease, ConfigMap, and Event permissions. If NetworkPolicy manager is not used in the environment, or its dependencies/API/RBAC are not ready, disable it in the upgrade values:
+
+```yaml
+manager:
+  enabled: false
+```
+
+Otherwise, the manager Pod may fail to start or repeatedly restart.

--- a/docs/en/navigation.yml
+++ b/docs/en/navigation.yml
@@ -1219,6 +1219,7 @@ nav:
                   - Installation: clawos/intro/install.md
                   - Quick Start: clawos/intro/quickstart.md
                   - Release Notes: clawos/intro/release-notes.md
+                  - Upgrade Notes: clawos/intro/upgrade-notes.md
               - Workspace View:
                   - Overview: clawos/workspace/overview.md
                   - ClawHub:

--- a/docs/zh/docs/clawos/intro/upgrade-notes.md
+++ b/docs/zh/docs/clawos/intro/upgrade-notes.md
@@ -15,13 +15,11 @@ v0.3.3 和 v0.5.3 的默认 OpenClaw 实例镜像不同：
 
 !!! note
 
-    升级 AgentClaw Helm Chart 只会更新实例模板和默认镜像配置，不会自动修改已经存在的 AgentInstance Deployment。升级完成后，需要对系统中的存量实例逐个执行更新或重启，使 OpenClaw 容器镜像切换到 `2026.7.1`。
-
-升级前请确认 `release.daocloud.io/agentclaw/openclaw:2026.7.1` 在当前环境可访问。镜像不可拉取会导致实例更新后进入 `ImagePullBackOff`。
+    升级完成后，需要对系统中的存量实例逐个执行更新，使 OpenClaw 容器镜像切换到 `2026.7.1`。
 
 ### SkillHub 配置
 
-升级时默认同时开启 ClawOS 的 SkillHub 能力和 SkillHub 子 Chart：
+v0.5.3 默认关闭 ClawOS 的 SkillHub 能，如需开启，请设置以下values:
 
 ```yaml
 skillhub:
@@ -32,7 +30,6 @@ skillhub:
 skillhubChart:
   enabled: true
   secrets:
-    bootstrapAdminPassword: <SkillHub 管理员密码>
     scannerLlmApiKey: <LLM API key>
     scannerLlmBaseUrl: http://<内网模型网关>:<端口>/v1
     scannerLlmModel: openai/public/minimax-m25
@@ -46,38 +43,7 @@ skillhubChart:
 
 其中：
 
-- `skillhub.publicHost` 必须填写集群中可被 OpenClaw 实例执行 `npx clawhub install` 访问的节点 IP 或域名。NodePort 会监听集群中的每个节点，不要求填写 master 节点。
-- `skillhubChart.secrets.scannerLlmApiKey`、`scannerLlmBaseUrl`、`scannerLlmModel` 和 `scanner.analyzers.llmProvider` 用于配置 Skill Scanner 的 LLM 分析。生产环境不要把真实 API key 提交到 values 文件。
+- `skillhub.publicHost` 必须填写集群中可被 OpenClaw 实例访问的节点 IP。NodePort 会监听集群中的每个节点，不要求填写 master 节点。
+- `skillhubChart.secrets.scannerLlmApiKey`、`scannerLlmBaseUrl`、`scannerLlmModel` 和 `scanner.analyzers.llmProvider` 用于配置 Skill Scanner 的 LLM 分析。
 - `scannerLlmBaseUrl` 应指向 OpenAI 兼容的 `/v1` 端点；`scannerLlmModel` 使用 LiteLLM 路由格式，例如 `openai/public/minimax-m25`。
 - `useLlm`、`useBehavioral` 和 `enableMeta` 同时开启时，Scanner 会组合 LLM 分析、行为分析和 meta 分析结果。
-
-启用 SkillHub 前，还需要确认：
-
-1. 发布的 AgentClaw Chart 包含 `charts/skillhub` 子 Chart，否则 Helm 依赖渲染会失败。
-2. SkillHub、PostgreSQL、Redis、Scanner 依赖的镜像在当前环境可拉取。
-3. 集群有可用的 StorageClass/PV，满足 SkillHub 的 PVC 要求。
-4. 默认 `global.ghippo.applyCR=true` 时，集群已安装 `ghippo.io/v1alpha1/GProductProxy` CRD。没有该 CRD 时，应关闭 `global.ghippo.applyCR`，否则 Helm 部署会失败。
-
-### manager 组件
-
-v0.5.3 默认新增并启用 NetworkPolicy manager：
-
-```yaml
-manager:
-  enabled: true
-  serviceAccount:
-    create: true
-```
-
-manager 需要访问 Kpanda 和 Clusterpedia，并使用 Lease、ConfigMap、Event 以及 ClusterPedia resources 相关权限。`manager.enabled=true` 且 `manager.serviceAccount.create=true` 时，Chart 会自动创建 manager 专用的 ServiceAccount、ClusterRole 和 ClusterRoleBinding，无需预先手工创建这些 RBAC 资源。
-
-升级时请确认执行 Helm 的身份有权限创建或更新集群级的 ClusterRole 和 ClusterRoleBinding。如果将 `manager.serviceAccount.create` 设置为 `false`，则需要提前提供已绑定上述权限的 ServiceAccount，否则 Helm 升级可能失败，或 manager Pod 因权限不足无法正常运行。
-
-如果当前环境不部署 NetworkPolicy manager，或 Kpanda/Clusterpedia 服务地址不可访问，可以在升级参数中关闭：
-
-```yaml
-manager:
-  enabled: false
-```
-
-否则 manager Pod 可能启动失败或反复重启。

--- a/docs/zh/docs/clawos/intro/upgrade-notes.md
+++ b/docs/zh/docs/clawos/intro/upgrade-notes.md
@@ -1,0 +1,77 @@
+# 升级注意事项
+
+本页说明将 ClawOS 从 v0.3.3 升级到 v0.5.3 时需要注意的事项。
+
+## 从 v0.3.3 升级到 v0.5.3
+
+### 存量实例镜像升级
+
+v0.3.3 和 v0.5.3 的默认 OpenClaw 实例镜像不同：
+
+- v0.3.3：`release.daocloud.io/agentclaw/openclaw:2026.4.7`
+- v0.5.3：`release.daocloud.io/agentclaw/openclaw:2026.7.1`
+
+`openclawPrevious` 在 v0.5.3 中为 `2026.6.10`，不属于本次存量实例统一升级目标。
+
+!!! note
+
+    升级 AgentClaw Helm Chart 只会更新实例模板和默认镜像配置，不会自动修改已经存在的 AgentInstance Deployment。升级完成后，需要对系统中的存量实例逐个执行更新或重启，使 OpenClaw 容器镜像切换到 `2026.7.1`。
+
+升级前请确认 `release.daocloud.io/agentclaw/openclaw:2026.7.1` 在当前环境可访问。镜像不可拉取会导致实例更新后进入 `ImagePullBackOff`。
+
+### SkillHub 配置
+
+升级时默认同时开启 ClawOS 的 SkillHub 能力和 SkillHub 子 Chart：
+
+```yaml
+skillhub:
+  enabled: true
+  # 集群外执行 npx clawhub install 时可访问的节点 IP 或域名
+  publicHost: <集群可访问的节点 IP 或域名>
+
+skillhubChart:
+  enabled: true
+  secrets:
+    bootstrapAdminPassword: <SkillHub 管理员密码>
+    scannerLlmApiKey: <LLM API key>
+    scannerLlmBaseUrl: http://<内网模型网关>:<端口>/v1
+    scannerLlmModel: openai/public/minimax-m25
+  scanner:
+    analyzers:
+      llmProvider: openai
+      useLlm: true
+      useBehavioral: true
+      enableMeta: true
+```
+
+其中：
+
+- `skillhub.publicHost` 必须填写集群中可被 OpenClaw 实例执行 `npx clawhub install` 访问的节点 IP 或域名。NodePort 会监听集群中的每个节点，不要求填写 master 节点。
+- `skillhubChart.secrets.scannerLlmApiKey`、`scannerLlmBaseUrl`、`scannerLlmModel` 和 `scanner.analyzers.llmProvider` 用于配置 Skill Scanner 的 LLM 分析。生产环境不要把真实 API key 提交到 values 文件。
+- `scannerLlmBaseUrl` 应指向 OpenAI 兼容的 `/v1` 端点；`scannerLlmModel` 使用 LiteLLM 路由格式，例如 `openai/public/minimax-m25`。
+- `useLlm`、`useBehavioral` 和 `enableMeta` 同时开启时，Scanner 会组合 LLM 分析、行为分析和 meta 分析结果。
+
+启用 SkillHub 前，还需要确认：
+
+1. 发布的 AgentClaw Chart 包含 `charts/skillhub` 子 Chart，否则 Helm 依赖渲染会失败。
+2. SkillHub、PostgreSQL、Redis、Scanner 依赖的镜像在当前环境可拉取。
+3. 集群有可用的 StorageClass/PV，满足 SkillHub 的 PVC 要求。
+4. 默认 `global.ghippo.applyCR=true` 时，集群已安装 `ghippo.io/v1alpha1/GProductProxy` CRD。没有该 CRD 时，应关闭 `global.ghippo.applyCR`，否则 Helm 部署会失败。
+
+### manager 组件
+
+v0.5.3 默认新增并启用 NetworkPolicy manager：
+
+```yaml
+manager:
+  enabled: true
+```
+
+manager 需要访问 Kpanda 和 Clusterpedia，并使用 Lease、ConfigMap、Event 相关权限。如果当前环境不部署 NetworkPolicy manager，或相关依赖/API/RBAC 尚未准备好，可以在升级参数中关闭：
+
+```yaml
+manager:
+  enabled: false
+```
+
+否则 manager Pod 可能启动失败或反复重启。

--- a/docs/zh/docs/clawos/intro/upgrade-notes.md
+++ b/docs/zh/docs/clawos/intro/upgrade-notes.md
@@ -65,9 +65,15 @@ v0.5.3 默认新增并启用 NetworkPolicy manager：
 ```yaml
 manager:
   enabled: true
+  serviceAccount:
+    create: true
 ```
 
-manager 需要访问 Kpanda 和 Clusterpedia，并使用 Lease、ConfigMap、Event 相关权限。如果当前环境不部署 NetworkPolicy manager，或相关依赖/API/RBAC 尚未准备好，可以在升级参数中关闭：
+manager 需要访问 Kpanda 和 Clusterpedia，并使用 Lease、ConfigMap、Event 以及 ClusterPedia resources 相关权限。`manager.enabled=true` 且 `manager.serviceAccount.create=true` 时，Chart 会自动创建 manager 专用的 ServiceAccount、ClusterRole 和 ClusterRoleBinding，无需预先手工创建这些 RBAC 资源。
+
+升级时请确认执行 Helm 的身份有权限创建或更新集群级的 ClusterRole 和 ClusterRoleBinding。如果将 `manager.serviceAccount.create` 设置为 `false`，则需要提前提供已绑定上述权限的 ServiceAccount，否则 Helm 升级可能失败，或 manager Pod 因权限不足无法正常运行。
+
+如果当前环境不部署 NetworkPolicy manager，或 Kpanda/Clusterpedia 服务地址不可访问，可以在升级参数中关闭：
 
 ```yaml
 manager:

--- a/docs/zh/navigation.yml
+++ b/docs/zh/navigation.yml
@@ -1300,6 +1300,7 @@ nav:
                   - 安装: clawos/intro/install.md
                   - 快速入门: clawos/intro/quickstart.md
                   - Release Notes: clawos/intro/release-notes.md
+                  - 升级注意事项: clawos/intro/upgrade-notes.md
               - 工作空间视角:
                   - 概览: clawos/workspace/overview.md
                   - ClawHub:


### PR DESCRIPTION
## Summary

- Add ClawOS v0.3.3 to v0.5.3 upgrade notes in Chinese and English.
- Document existing instance image migration to `2026.7.1`.
- Document SkillHub and manager settings that may affect deployment.
- Remove the upgrade procedure section as requested.

## Validation

- `git diff --check`
- Verified Markdown code fences and required SkillHub parameters.
- Verified no private model gateway address is included.
