### PR TITLE
disable git-revision-date-localized to improve build speed

### DIFF
--- a/docs/en/mkdocs.path.yaml
+++ b/docs/en/mkdocs.path.yaml
@@ -117,14 +117,14 @@ plugins:
 
   # - git-revision-date: # Display the last update date on the bottom of each page, install with 'pip install mkdocs-git-revision-date-plugin'
   #     enabled_if_env: "CI"
-  - git-revision-date-localized: # Add localized creation and update dates on the bottom of each page
-      timezone: Asia/Shanghai
-      type: date # Date format, valid values are 'date', 'datetime', 'iso_date', 'iso_datetime', 'timeago'
-      fallback_to_build_date: true # Default is false, enables fallback to time when mkdocs build was executed
-      enable_creation_date: false # Set to true to also show the file creation date
-      exclude:
-        - index.md
-      enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
+  # - git-revision-date-localized: # Add localized creation and update dates on the bottom of each page (disabled: slows build)
+  #     timezone: Asia/Shanghai
+  #     type: date
+  #     fallback_to_build_date: true
+  #     enable_creation_date: false
+  #     exclude:
+  #       - index.md
+  #     enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
 
   # auto desgin nav in dirs
   # - awesome-pages:

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -137,14 +137,14 @@ plugins:
 
   # - git-revision-date: # Display the last update date on the bottom of each page, install with 'pip install mkdocs-git-revision-date-plugin'
   #     enabled_if_env: "CI"
-  - git-revision-date-localized: # Add localized creation and update dates on the bottom of each page
-      timezone: Asia/Shanghai
-      type: date # Date format, valid values are 'date', 'datetime', 'iso_date', 'iso_datetime', 'timeago'
-      fallback_to_build_date: true # Default is false, enables fallback to time when mkdocs build was executed
-      enable_creation_date: false # Set to true to also show the file creation date
-      exclude:
-        - index.md
-      enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
+  # - git-revision-date-localized: # Add localized creation and update dates on the bottom of each page (disabled: slows build)
+  #     timezone: Asia/Shanghai
+  #     type: date
+  #     fallback_to_build_date: true
+  #     enable_creation_date: false
+  #     exclude:
+  #       - index.md
+  #     enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
 
   # auto desgin nav in dirs
   # - awesome-pages:

--- a/docs/zh/mkdocs.path.yaml
+++ b/docs/zh/mkdocs.path.yaml
@@ -142,14 +142,14 @@ plugins:
 
   # - git-revision-date: #每页底部显示文档最后更新日期，安装 pip install mkdocs-git-revision-date-plugin
   #     enabled_if_env: "CI"
-  - git-revision-date-localized: #每个页面底部添加本地化更新和创建日期
-      timezone: Asia/Shanghai
-      type: date #日期格式，有效值为 date、datetime、iso_date、iso_datetime、timeago
-      fallback_to_build_date: true #默认 false，启用则回退到 mkdocs build 执行的时间
-      enable_creation_date: false #设为 true 时同时显示创建日期和最后更新日期
-      exclude:
-        - index.md
-      enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
+  # - git-revision-date-localized: #每个页面底部添加本地化更新和创建日期（已禁用：拖慢 build）
+  #     timezone: Asia/Shanghai
+  #     type: date
+  #     fallback_to_build_date: true
+  #     enable_creation_date: false
+  #     exclude:
+  #       - index.md
+  #     enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
 
   # auto desgin nav in dirs
   # - awesome-pages:

--- a/docs/zh/mkdocs.yml
+++ b/docs/zh/mkdocs.yml
@@ -155,14 +155,14 @@ plugins:
 
   # - git-revision-date: #每页底部显示文档最后更新日期，安装 pip install mkdocs-git-revision-date-plugin
   #     enabled_if_env: "CI"
-  - git-revision-date-localized: #每个页面底部添加本地化更新和创建日期
-      timezone: Asia/Shanghai
-      type: date #日期格式，有效值为 date、datetime、iso_date、iso_datetime、timeago
-      fallback_to_build_date: true #默认 false，启用则回退到 mkdocs build 执行的时间
-      enable_creation_date: false #设为 true 时同时显示创建日期和最后更新日期
-      exclude:
-        - index.md
-      enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
+  # - git-revision-date-localized: #每个页面底部添加本地化更新和创建日期（已禁用：拖慢 build）
+  #     timezone: Asia/Shanghai
+  #     type: date
+  #     fallback_to_build_date: true
+  #     enable_creation_date: false
+  #     exclude:
+  #       - index.md
+  #     enabled: !ENV [ENABLED_GIT_REVISION_DATE, true]
 
   # auto desgin nav in dirs
   # - awesome-pages:


### PR DESCRIPTION
Related to #7318 

enable 这个插件后 build 速度太慢了，需要 15-20 分钟来build，所以先 disable 了